### PR TITLE
Create-dot-env related reworks

### DIFF
--- a/4make/inside-chroot/focal-headless.sh
+++ b/4make/inside-chroot/focal-headless.sh
@@ -58,7 +58,8 @@ EOS
 }
 
 add_source_locale_snippet() {
-    for file in '/root/.bashrc' "/home/${MASH_USER}/.bashrc"; do
+    files="/root/.bashrc /home/${MASH_USER}/.bashrc"
+    for file in $files; do
         cat >> "$file" << EOS
 
 # $(basename "$0"): sourcing locale:

--- a/scripts/create-dot-env.sh
+++ b/scripts/create-dot-env.sh
@@ -48,6 +48,20 @@ should_be_processed() {
     has_substr "$line" '=' && has_substr "$line" '$${'
 }
 
+#do_positive_test() {
+#    case_no=$(expr $case_no + 1)
+#    if should_be_processed "$1"; then echo " case-$case_no OK"; else
+#        echo " case-$case_no FAILED"
+#    fi
+#}
+#
+#do_negative_test() {
+#    case_no=$(expr $case_no + 1)
+#    if ! should_be_processed "$1"; then echo " case-$case_no OK"; else
+#        echo " case-$case_no FAILED"
+#    fi
+#}
+
 main() {
     local OIFS="$IFS"
     local IFS=''

--- a/scripts/create-dot-env.sh
+++ b/scripts/create-dot-env.sh
@@ -2,64 +2,30 @@
 #: Parse `.env.mk.sample` and spit an output to stdout which is suitable
 #: to become the `.env` of the chroot-setup.
 
+# shellcheck disable=1091
+# . "$(dirname "$0")/small-lib.sh"
+. ./scripts/small-lib.sh
+
 _name_="$(basename "$0")"
+_cde_name_='create-dot-env.sh'
+echo "$_cde_name_: _name_=[$_name_], _cde_name_=[$_cde_name_]"
+
 ENV_SAMPLE_FILE='.env.mk.sample'
-
-die() {
-    rc="$1"
-    errmsg="$2"
-
-    printf "%s\n" "$errmsg"
-    exit "$rc"
-}
-
-#: Return success if "$2" is found within "$1", otherwise fail.
-#: If $1 is empty, fail with '1', If $2 is empty, die promptly with 101
-#: as behavior is undefined for $2=''.
-has_substr() {
-    [ -z "$1" ] && return 1 # empty string does not contain anything
-    [ -z "$2" ] && die 101 "has_substr(): illegal call with empty substring."
-    [ -z "${1##*$2*}" ]
-}
-
-#: Evaluates the string argument and prints the resulting string.
-reeval() {
-    eval "printf '%s' $1"
-}
-
-#: Assign multiple space-delimited values of "$1" to multiple variables
-#: given as the remaining arguments. Example:
-#:   assing_multiple "ONE TWO THREE" one two three
-assing_multiple() {
-    # IMPORTANT: IFS *must* be set *first* as it affects $* and $@!
-    OIFS_1="$IFS"
-    IFS=' '
-
-    multiple_values="$1"
-    shift
-    varnames="$*"
-
-    # shellcheck disable=2086,2229
-    read -r $varnames << EOS
-$multiple_values
-EOS
-    IFS="$OIFS_1"
-}
 
 #: If this is an assignment, split the line into lhs (the lhs) and rhs
 #: and echo back the lhs, the assign operator and the rhs, space-delimited;
 #: othereise fail.
 split_line() {
-    line="$1"
+    local line="$1"
 
-    # just double-checking
+    # must already be true but we double-check
     has_substr "$line" '=' || {
         die 101 "$_name_: Expected line with assignment, got [$line]"
     }
 
-    assign='??'
-    lhs='??'
-    rhs='??'
+    local assign='??'
+    local lhs='??'
+    local rhs='??'
 
     if has_substr "$line" ':='; then
         assign=':='
@@ -77,31 +43,26 @@ split_line() {
     printf '%s %s %s\n' "$lhs" "$assign" "$rhs"
 }
 
-should_not_be_processed() {
-    line="$1"
-    ! has_substr "$line" '=' || {
-        has_substr "$line" '$$' && ! has_substr "$line" '$${'
-    }
+should_be_processed() {
+    local line="$1"
+    has_substr "$line" '=' && has_substr "$line" '$${'
 }
 
 main() {
-    OIFS_2="$IFS"
-    IFS=''
+    local OIFS="$IFS"
+    local IFS=''
     while read -r line; do
 
-        if ! has_substr "$line" '='; then
-            printf '%s\n' "$line"
-            continue
-        elif has_substr "$line" '$$' && ! has_substr "$line" '$${'; then
-            # preserve lines that happen to have $$ but it is not a variable reference
+        if ! should_be_processed "$line"; then
             printf '%s\n' "$line"
             continue
         fi
 
         #else:
-        lhs='??'
-        assign='??'
-        rhs='??'
+
+        local lhs='??'
+        local assign='??'
+        local rhs='??'
 
         splitted="$(split_line "$line" || die 102 'INTERNAL (51965)')"
         assing_multiple "$splitted" lhs assign rhs
@@ -113,52 +74,9 @@ main() {
         echo "${lhs} ${assign} ${rhs}"
 
     done < "$ENV_SAMPLE_FILE"
-    IFS="$OIFS_2"
+    IFS="$OIFS"
 }
 
-test_has_substr() {
-    printf '%s\n' 'POSITIVE:'
-    has_substr 'abc' 'a'
-    echo "rc=$?"
-    has_substr 'abc' 'ab'
-    echo "rc=$?"
-    has_substr 'abc' 'bc'
-    echo "rc=$?"
-    has_substr 'abc' 'abc'
-    echo "rc=$?"
-    has_substr 'ab$$c' '$$'
-    echo "rc=$?"
-
-    printf '%s\n' 'NEGATIVE:'
-    has_substr '' 'ab'
-    echo "rc=$?"
-    has_substr 'abc' 'ac'
-    echo "rc=$?"
-    has_substr 'abc' 'ba'
-    echo "rc=$?"
-    has_substr 'aabca' 'ba'
-    echo "rc=$?"
-
-    # must be last as the call exits
-    printf '%s\n' 'DIES:'
-    has_substr "abc" ''
-    echo "rc=$?"
-}
-
-test_assign_multiple() {
-    assing_multiple 'CHROOT  :=  /tmp/mash-ramdisk' lhs assign rhs
-    printf 'lhs=[%s] assign=[%s] rhs=[%s]\n' "$lhs" "$assign" "$rhs"
-}
-
-test() {
-    test_assign_multiple
-
-    # must be last as it exits at the end
-    test_has_substr
-}
-
-if [ "${1:-main}" = test ]; then
-    test
-else
+if [ "$_name_" = "$_cde_name_" ]; then
     main
 fi

--- a/scripts/expand-vars.sh
+++ b/scripts/expand-vars.sh
@@ -1,0 +1,22 @@
+#! /bin/sh
+
+# shellcheck disable=2034
+
+MASH_USER=mash
+MASH_UID=1234
+
+
+expand_vars() {
+    local file="$1"
+    local varnames="$2"
+
+    content="$(cat "$1")"
+    for varname in $varnames; do
+        sed_arg="s:\${\?$varname}\?:$(eval "echo \$$varname"):g"
+        printf '\n%s\n\n' "$sed_arg"
+        content="$(printf '%s' "$content" | sed "$sed_arg" )"
+    done
+    printf '%s' "$content"
+}
+
+expand_vars ./run-tests.sh "MASH_USER MASH_UID"

--- a/scripts/path-lib.sh
+++ b/scripts/path-lib.sh
@@ -1,0 +1,25 @@
+#! /bin/sh
+# path-lib.sh should be sourced.
+
+
+#: Returns a relative part of given path $1 from given directory $2 to
+#: the end of the path, stripping the part from the beginning to the
+#: given directory.
+relpath_from_dir() {
+    local path="$1"
+    local dir="$2"
+
+    echo "$path" | sed "s:^.*/\?\($dir/.*$\):\1:"
+}
+
+
+test_relpath_from_dir() {
+    res="$(relpath_from_dir '/one/two/three/four/five' 'three')"  # expected three/four/five
+    echo $res
+    res="$(relpath_from_dir '/one/two/three/four/five' 'one')"  # expected one/two/three/four/five
+    echo $res
+    res="$(relpath_from_dir '/one/two/three/four/five' 'five')"  # expected three/four/five'
+    echo $res
+}
+
+test_relpath_from_dir

--- a/scripts/small-lib.sh
+++ b/scripts/small-lib.sh
@@ -1,0 +1,46 @@
+#! /bin/sh
+#
+# small-lib.sh -- a small library of helper funcions.
+# This file is supposed to be sourced; shebang is only for shellcheck
+# to know the shell and for running the tests.
+
+die() {
+    rc="$1"
+    errmsg="$2"
+
+    printf "%s\n" "$errmsg"
+    exit "$rc"
+}
+
+#: Return success if "$2" is found within "$1", otherwise fail.
+#: If $1 is empty, fail with '1', If $2 is empty, die promptly with 101
+#: as behavior is undefined for $2=''.
+has_substr() {
+    [ -z "$1" ] && return 1 # empty string does not contain anything
+    [ -z "$2" ] && return 2 # illegal call with empty substring
+    [ -z "${1##*$2*}" ]
+}
+
+#: Evaluates the string argument and prints the resulting string.
+reeval() {
+    eval "printf '%s' $1"
+}
+
+#: Assign multiple space-delimited values of "$1" to multiple variables
+#: given as the remaining arguments. Example:
+#:   assing_multiple "ONE TWO THREE" one two three
+assing_multiple() {
+    # IMPORTANT: IFS *must* be set *first* as it affects $* and $@!
+    OIFS_1="$IFS"
+    IFS=' '
+
+    multiple_values="$1"
+    shift
+    varnames="$*"
+
+    # shellcheck disable=2086,2229
+    read -r $varnames << EOS
+$multiple_values
+EOS
+    IFS="$OIFS_1"
+}

--- a/scripts/tests/expected-output-create-dot-env.dump
+++ b/scripts/tests/expected-output-create-dot-env.dump
@@ -1,0 +1,36 @@
+# Makefile variables - default (sample) values.
+# Note that the syntax is Makefile, NOT unix shell!
+#
+# You MUST use double dollar ($$) and curly braces ({}) for shell
+# variables, like:
+#   $${SHELL_VAR}
+# or the ./scripts/create-dot-env.sh will not make the substitution
+# when creating `.env.mk` out of `.env.mk.sample`.
+#
+# Execute `./scripts/create-dot-env.sh` to generate an initial `.env`
+# file. You should be good to go then, the defaults should work for
+# (almost) all cases (but feel free to tune anything, if needed).
+
+CHROOT := /tmp/mash-ramdisk
+CODENAME := focal
+MIRROR_URL := http://bg.archive.ubuntu.com/ubuntu
+DOWNLOAD_DIR := ./downloads
+
+MASH_USER := mash
+MASH_UID := 1234
+MASH_PSSWD_HASH_DEFAULT := $$6$$coq/LvbNylektqbU$$yZ02jL5Q2mSPlL1VnLEb9jnenFqDRbslk9jbRQ.RCRNMtxwCH//NWYK.zowhjFFm6N5RI9WPVI4kWgcX2jDoV/
+MASH_PSSWD_HASH := $(MASH_PSSWD_HASH_DEFAULT)
+
+BUILD_DIR := build
+
+# Note that tar archive filename extention (.gz, .xz) can be overriden later
+# on, so not added here. TAR_EXT can be one of gz, xz, bz2 (see 'man tar').
+#
+# Some statistics:
+#  File size: focal-headless.tgz is 132Mb, focal-mate-desktop.txz is 90Mb (-31%)
+#  Un-archiaval time:  focal-headless.tgz: 2.6s (-62%), focal-mate-desktop.txz 6.8s
+
+TAR_EXT := gz
+TAR_FILE_TEMPLATE = $(BUILD_DIR)/$(CODENAME)-$(TARGET_NAME).tar
+FOCAL_HEADLESS_TAR = $(BUILD_DIR)/$(CODENAME)-headless.tar
+MATE_DESKTOP_TAR = $(BUILD_DIR)/$(CODENAME)-mate-desktop.tar

--- a/scripts/tests/lib-4test.sh
+++ b/scripts/tests/lib-4test.sh
@@ -1,0 +1,386 @@
+#! /bin/sh
+#
+# lib-4tests.py
+# Library with test utility functions like `assert_equal()`.
+# Should be sourced; execution makes sense only for running its own tests.
+# (Use 'test' as first (and only) argument when you want to do do.)
+
+# TODO: currently print_pass executes always,
+#   even if one or more of the sub-tests fail.
+
+_name_="$(basename "$0")"
+_l4t_name_='lib-4test.sh'
+echo "$_l4t_name_: _name_=[$_name_], _l4t_name_=[$_l4t_name_]"
+
+_curr_test_=''
+
+is_num() {
+    [ "$1" -eq "$1" ] 2> /dev/null
+}
+
+# shellcheck disable=2120
+print_pass() {
+    passmsg="${1:-passed}"
+    printf 'ok %u - %s: %s\n' $no $_curr_test_ "$passmsg"
+}
+
+print_fail() {
+    failmsg="$1"
+    printf 'not ok %u - %s: %s\n' $no $_curr_test_ "$failmsg"
+}
+
+print_error() {
+    failmsg="$1"
+    out=${2:-/dev/stderr}
+    printf '%s: %s\n' $_curr_test_ "$failmsg" >> $out
+}
+
+check_arg_is_num() {
+    local arg="$1"
+    local arg_name="$2"
+
+    is_num "$arg" || {
+        print_error "$arg_name=[$arg] is NOT an integer"
+        return 1
+    }
+}
+
+check_two_args_are_num() {
+    local actual="$1"
+    local expected="$2"
+
+    check_arg_is_num "$expected" expected && check_arg_is_num "$actual" actual
+}
+
+assert_equal() {
+    local actual="$1"
+    local expected="$2"
+
+    if [ "$actual" != "$expected" ]; then
+        print_fail "assert_equal FAILED: '$actual' != '$expected'"
+        return 1
+    fi
+}
+
+assert_equal_num() {
+    check_two_args_are_num "$1" "$2" || return 1
+
+    local actual="$1"
+    local expected="$2"
+
+    # shellcheck disable=2086
+    if [ $actual -ne $expected ] 2> /dev/null; then
+        print_fail "assert_equal_num FAILED: '$actual' != '$expected'"
+        return 1
+    fi
+}
+
+assert_not_equal() {
+    local actual="$1"
+    local expected="$2"
+
+    # shellcheck disable=2003,2086
+    if [ "$actual" = "$expected" ]; then
+        print_fail "assert_not_equal FAILED: '$actual' = '$expected'"
+        return 1
+    fi
+}
+
+assert_not_equal_num() {
+    check_two_args_are_num "$1" "$2" || return 1
+
+    local actual="$1"
+    local expected="$2"
+
+    # shellcheck disable=2003,2086
+    if [ $actual -eq $expected ]; then
+        print_fail "assert_not_equal_num FAILED: '$actual' != '$expected'"
+        return 1
+    fi
+}
+
+assert_true() {
+    local cmd="$*"
+
+    $cmd || {
+        print_fail "assert_true FAILED for [$cmd]"
+        return 1
+    }
+}
+
+assert_false() {
+    local cmd="$*"
+
+    ! $cmd || {
+        print_fail "assert_true FAILED for [$cmd]"
+        return 1
+    }
+}
+
+assert_rc_equal() {
+    local expected_rc="$1"
+    check_arg_is_num "$expected_rc" expected_rc || return 1
+    shift
+    local cmd="$*"
+
+    $cmd
+    [ "$?" != "$expected_rc" ]
+}
+
+# ___________________________________________
+# Test section below
+
+test_is_num__true() {
+    _curr_test_=test_is_num__true
+    no=$(expr $no + 1)
+
+    is_num 345 || print_fail "345 not accepted as integer"
+    is_num 34 || print_fail "34 not accepted as integer"
+    is_num 3 || print_fail "3 not accepted as integer"
+    is_num 0 || print_fail "0 not accepted as integer"
+    is_num -0 || print_fail "-0 not accepted as integer"
+    is_num -345 || print_fail "-345 not accepted as integer"
+    is_num +345 || print_fail "+345 not accepted as integer"
+
+    # shellcheck disable=2119
+    print_pass
+}
+
+test_is_num__false() {
+    _curr_test_=test_is_num__false
+    no=$(expr $no + 1)
+
+    is_num '34a' && print_fail "34a accepted as integer"
+    is_num '34.5' && print_fail "34.5 accepted as integer"
+    is_num '' && print_fail "empty string accepted as integer"
+
+    # shellcheck disable=2119
+    print_pass
+}
+
+test_assert_equal__positive() {
+    _curr_test_=test_assert_equal__positive
+    # shellcheck disable=2003,2086
+    no=$(expr $no + 1)
+
+    assert_equal tata tata
+    assert_equal 123 123
+    assert_equal '' ''
+
+    # shellcheck disable=2119
+    print_pass
+}
+
+test_assert_equal__negative() {
+    _curr_test_=test_assert_equal__negative
+    # shellcheck disable=2003,2086
+    no=$(expr $no + 1)
+
+    assert_equal tata toto 1> /dev/null && print_fail 'assert_equal tata toto DID NOT fail'
+    assert_equal '' toto 1> /dev/null && print_fail 'assert_equal '' toto DID NOT fail'
+    assert_equal tata '' 1> /dev/null && print_fail 'assert_equal tata '' DID NOT fail'
+    assert_equal ' ' '' 1> /dev/null && print_fail 'assert_equal ' ' '' DID NOT fail'
+
+    # shellcheck disable=2119
+    print_pass
+}
+
+test_assert_not_equal__positive() {
+    _curr_test_=test_assert_not_equal__positive
+    # shellcheck disable=2003,2086
+    no=$(expr $no + 1)
+
+    assert_not_equal tata toto
+    assert_not_equal '' toto
+    assert_not_equal tata ''
+    assert_not_equal ' ' ''
+
+    # shellcheck disable=2119
+    print_pass
+}
+
+test_assert_not_equal__negative() {
+    _curr_test_=test_assert_not_equal__negative
+    # shellcheck disable=2003,2086
+    no=$(expr $no + 1)
+
+    assert_not_equal tata tata 1> /dev/null && print_fail 'assert_not_equal tata toto DID NOT fail'
+    assert_not_equal 123 123 1> /dev/null && print_fail 'assert_not_equal 123 123 DID NOT fail'
+    assert_not_equal '' '' 1> /dev/null && print_fail 'assert_not_equal '' '' DID NOT fail'
+
+    # shellcheck disable=2119
+    print_pass
+}
+
+test_assert_equal_num__positive() {
+    _curr_test_=test_assert_equal_num__positive
+    # shellcheck disable=2003,2086
+    no=$(expr $no + 1)
+
+    assert_equal_num 123 123
+    assert_equal_num 123 0123
+    assert_equal_num -000123 -0123
+    assert_equal_num 0 0
+    assert_equal_num -0 +0
+    assert_equal_num '123' '123'
+    assert_equal_num 123 '123'
+    assert_equal_num '123' 123
+    assert_equal_num '123 ' ' 123'
+
+    # shellcheck disable=2119
+    print_pass
+}
+
+test_assert_equal_num__negative() {
+    _curr_test_=test_assert_equal_num__negative
+    # shellcheck disable=2003,2086
+    no=$(expr $no + 1)
+
+    # 2> /dev/null
+
+    assert_equal_num 123 124 1> /dev/null && print_fail 'assert_equal_num 123 124 DID NOT fail'
+    assert_equal_num -1 1 1> /dev/null && print_fail 'assert_equal_num -1 1 DID NOT fail'
+    assert_equal_num 2 2a 1> /dev/null && print_fail 'assert_equal_num 2 2a DID NOT fail'
+
+    # shellcheck disable=2119
+    print_pass
+}
+
+test_assert_not_equal_num__positive() {
+    _curr_test_=test_assert_not_equal_num__positive
+    # shellcheck disable=2003,2086
+    no=$(expr $no + 1)
+
+    assert_not_equal_num 123 124
+    assert_not_equal_num 1 -1
+    assert_not_equal_num 1 -1a
+
+    # shellcheck disable=2119
+    print_pass
+}
+
+test_assert_not_equal_num__negative() {
+    _curr_test_=test_assert_not_equal_num__negative
+    # shellcheck disable=2003,2086
+    no=$(expr $no + 1)
+
+    assert_not_equal_num 123 123 1> /dev/null && print_fail 'assert_not_equal_num 123 123 DID NOT fail'
+    assert_not_equal_num 0234 00234 1> /dev/null && print_fail 'assert_not_equal_num 0234 00234 DID NOT fail'
+    assert_not_equal_num '  234 ' 0000234 1> /dev/null && print_fail 'assert_not_equal_num ' 234 ' 0000234 DID NOT fail'
+
+    # shellcheck disable=2119
+    print_pass
+}
+
+test_assert_true__positive() {
+    _curr_test_=test_assert_true__positive
+    # shellcheck disable=2003,2086
+    no=$(expr $no + 1)
+
+    assert_true true
+    assert_true [ 1 -eq 1 ]
+    assert_true [ abc = abc ]
+
+    # shellcheck disable=2119
+    print_pass
+}
+
+test_assert_true__negative() {
+    _curr_test_=test_assert_true__negative
+    # shellcheck disable=2003,2086
+    no=$(expr $no + 1)
+
+    assert_true false 1> /dev/null && print_fail 'assert_true false DID NOT fail'
+    assert_true [ 1 -eq 0 ] 1> /dev/null && print_fail 'assert_true [ 1 -eq 0 ] DID NOT fail'
+    assert_true [ abc = cba ] 1> /dev/null && print_fail 'assert_true [ abc = cba ] DID NOT fail'
+
+    # shellcheck disable=2119
+    print_pass
+}
+
+test_assert_false__positive() {
+    _curr_test_=test_assert_false__positive
+    # shellcheck disable=2003,2086
+    no=$(expr $no + 1)
+
+    assert_false false
+    assert_false [ 1 -eq 2 ]
+    assert_false [ abc = asd ]
+
+    # shellcheck disable=2119
+    print_pass
+}
+
+test_assert_false__negative() {
+    _curr_test_=test_assert_false__negative
+    # shellcheck disable=2003,2086
+    no=$(expr $no + 1)
+
+    assert_false true 1> /dev/null && print_fail 'assert_false true DID NOT fail'
+    assert_false [ 3 -eq 3 ] 1> /dev/null && print_fail 'assert_false [ 3 -eq 3 ] DID NOT fail'
+    assert_false [ asd = asd ] 1> /dev/null && print_fail 'assert_false [ asd = asd ] DID NOT fail'
+
+    # shellcheck disable=2119
+    print_pass
+}
+
+test_assert_rc_equal__positive() {
+    _curr_test_=test_assert_rc_equal__positive
+    # shellcheck disable=2003,2086
+    no=$(expr $no + 1)
+
+    assert_rc_equal 1 true
+    assert_rc_equal 0 false
+    assert_rc_equal 5 return 5
+    assert_rc_equal 127 return 127
+
+    # shellcheck disable=2119
+    print_pass
+}
+test_assert_rc_equal__negative() {
+    _curr_test_=test_assert_rc_equal__negative
+    # shellcheck disable=2003,2086
+    no=$(expr $no + 1)
+
+    assert_rc_equal 1 false 1> /dev/null && print_fail 'assert_rc_equal 1 false DID NOT fail'
+    assert_rc_equal 0 true 1> /dev/null && print_fail 'assert_rc_equal 0 true DID NOT fail'
+    assert_rc_equal 5 return 6 1> /dev/null && print_fail 'assert_rc_equal 5 return 6 DID NOT fail'
+    assert_rc_equal 127 return 126 1> /dev/null && print_fail 'assert_rc_equal 127 return 126 DID NOT fail'
+    assert_rc_equal abs return 0 && print_fail 'assert_rc_equal abs return 0 DID NOT fail'
+
+    # shellcheck disable=2119
+    print_pass
+}
+
+# shellcheck disable=2003,2086
+test() {
+    set +x
+    local rc=0
+
+    test_is_num__true
+    test_is_num__false
+    test_assert_equal__positive
+    test_assert_equal__negative
+    test_assert_not_equal__positive
+    test_assert_not_equal__negative
+    test_assert_equal_num__positive
+    test_assert_equal_num__negative
+    test_assert_not_equal_num__positive
+    test_assert_not_equal_num__negative
+    test_assert_true__positive
+    test_assert_true__negative
+    test_assert_false__positive
+    test_assert_false__negative
+    test_assert_rc_equal__positive
+    test_assert_rc_equal__negative
+}
+
+if [ "$_name_" = "$_l4t_name_" ]; then
+    if [ "$1" = test ]; then
+        test
+    else
+        echo "$_l4t_name_ is a library - not callable directly."
+        echo "If you want to run the tests -- use 'test' argument."
+        exit 1
+    fi
+fi

--- a/scripts/tests/test-create-dot-env.sh
+++ b/scripts/tests/test-create-dot-env.sh
@@ -1,0 +1,107 @@
+#! /bin/sh
+# Tests for create-dot-env.sh. Can be executed directly or sourced.
+
+# shellcheck disable=1091
+{
+    # Paths are relative to the chroot-setup project root
+    . ./scripts/create-dot-env.sh
+    . ./scripts/tests/lib-4test.sh
+}
+
+# must follow the imports otherwise _tcde_name_ gets overriden
+_name_="$(basename "$0")"
+_tcde_name_='test-create-dot-env.sh'
+echo "$_tcde_name_: _name_=[$_name_], _tcde_name_=[$_tcde_name_]"
+
+# shellcheck disable=2003,2016
+test_split_line() {
+    printf '%s\n' 'test_split_line:'
+    local no=0
+
+    _assert_equal() {
+        no=$(expr $no + 1)
+        expected="$1"
+        actual="$2"
+        if [ "$actual" = "$expected" ]; then echo " case-$no OK"; else
+            echo " case-$no FAILED: [$actual] != [$expected]"
+        fi
+    }
+
+    _assert_equal 'TAR_EXT := $${MASH_CHROOT_TAR_EXT:-gz}' "$(split_line 'TAR_EXT:=$${MASH_CHROOT_TAR_EXT:-gz}')"
+    rc=$(expr $rc + $?)
+    _assert_equal 'TAR_EXT  :=  $${MASH_CHROOT_TAR_EXT:-gz}' "$(split_line 'TAR_EXT := $${MASH_CHROOT_TAR_EXT:-gz}')"
+    rc=$(expr $rc + $?)
+    return $rc
+}
+
+# shellcheck disable=2003,2016
+test_should_be_processed() {
+    printf '%s\n' 'test_should_be_processed:'
+    local rc=0
+    local no=0 # test case number
+
+    do_positive_test() {
+        no=$(expr $no + 1)
+        if should_be_processed "$1"; then echo " case-$no OK"; else
+            echo " case-$no FAILED"
+            rc=$(expr $rc + 1)
+        fi
+    }
+
+    do_negative_test() {
+        no=$(expr $no + 1)
+        if ! should_be_processed "$1"; then echo " case-$no OK"; else
+            echo " case-$no FAILED"
+            rc=$(expr $rc + 1)
+        fi
+    }
+
+    do_positive_test 'TAR_EXT := $${MASH_CHROOT_TAR_EXT:-gz}'
+    do_positive_test 'MASH_PSSWD_HASH := $${MASH_CHROOT_USER_PSSWD_HASH:-\$(MASH_PSSWD_HASH_DEFAULT)}'
+    do_negative_test 'MASH_PSSWD_HASH_DEFAULT := $$6$$coq/LvbNy'
+    do_negative_test 'MASH_USER := mash'
+    # do_positive_test 'MASH_USER := mash'  # fails - for checking how it runs with a failng test
+    return $rc
+}
+
+test_e2e() {
+    local rc=0
+    local tmp_file='/tmp/create-dot-env-4test.dump'
+    local ref_file='scripts/tests/expected-output-create-dot-env.dump'
+
+    main > "$tmp_file"
+    if diff -u "$tmp_file" "$ref_file"; then
+        printf 'e2e test OK\n'
+    else
+        printf 'e2e test FAILED; diff is above ^^\n'
+        rc=1
+    fi
+    rm $tmp_file
+    return $rc
+}
+
+# shellcheck disable=2003,2086
+test() {
+    local rc=0
+
+    echo ''
+    test_split_line
+    rc=$(expr $rc + $?)
+    echo ''
+
+    test_should_be_processed
+    rc=$(expr $rc + $?)
+    echo ''
+
+    test_e2e
+    rc=$(expr $rc + $?)
+
+    printf "\n%s:" "$_tcde_name_"
+    [ "$rc" = 0 ] && printf ' SUCCESS!' || printf '  Testing FAILED.'
+    printf '  Failed tests: %u\n' $rc
+    return $rc
+}
+
+if [ "$_name_" = "$_tcde_name_" ]; then
+    test
+fi

--- a/scripts/tests/test-small-lib.sh
+++ b/scripts/tests/test-small-lib.sh
@@ -13,71 +13,85 @@ _name_="$(basename "$0")"
 _tsl_name_='test-small-lib.sh'
 echo "$_tsl_name_: _name_=[$_name_], _tsl_name_=[$_tsl_name_]"
 
-test_has_substr_OLD() {
-    printf '%s\n' 'POSITIVE:'
-    has_substr 'abc' 'a'
-    echo "rc=$?"
-    has_substr 'abc' 'ab'
-    echo "rc=$?"
-    has_substr 'abc' 'bc'
-    echo "rc=$?"
-    has_substr 'abc' 'abc'
-    echo "rc=$?"
-    has_substr 'ab$$c' '$$'
-    echo "rc=$?"
+test_has_substr__true() {
+    _curr_test_=test_has_substr__true
+    no=$(expr $no + 1)
 
-    printf '%s\n' 'NEGATIVE:'
-    has_substr '' 'ab'
-    echo "rc=$?"
-    has_substr 'abc' 'ac'
-    echo "rc=$?"
-    has_substr 'abc' 'ba'
-    echo "rc=$?"
-    has_substr 'aabca' 'ba'
-    echo "rc=$?"
-    has_substr "abc" ''
-    echo "rc=$?"
+    assert_true has_substr 'abc' 'a'
+    assert_true has_substr 'abc' 'ab'
+    assert_true has_substr 'abc' 'bc'
+    assert_true has_substr 'abc' 'abc'
+    assert_true has_substr 'ab$$c' '$$'
+
+    print_pass
 }
 
-test_has_substr() {
-    printf '%s\n' 'POSITIVE:'
-    has_substr 'abc' 'a'
-    echo "rc=$?"
-    has_substr 'abc' 'ab'
-    echo "rc=$?"
-    has_substr 'abc' 'bc'
-    echo "rc=$?"
-    has_substr 'abc' 'abc'
-    echo "rc=$?"
-    has_substr 'ab$$c' '$$'
-    echo "rc=$?"
+test_has_substr__false() {
+    _curr_test_=test_has_substr__false
+    no=$(expr $no + 1)
 
-    printf '%s\n' 'NEGATIVE:'
-    has_substr '' 'ab'
-    echo "rc=$?"
-    has_substr 'abc' 'ac'
-    echo "rc=$?"
-    has_substr 'abc' 'ba'
-    echo "rc=$?"
-    has_substr 'aabca' 'ba'
-    echo "rc=$?"
-    has_substr "abc" ''
-    echo "rc=$?"
+    assert_false has_substr 'abc' 'x'
+    assert_false has_substr '' 'ab'
+    assert_false has_substr 'abc' 'ac'
+    assert_false has_substr 'abc' 'ba'
+    assert_false has_substr "abc" ''
+
+    print_pass
 }
 
-test_assign_multiple() {
+test_assign_multiple__case_exact() {
+    _curr_test_=test_assign_multiple__case_exact
+    no=$(expr $no + 1)
+
+    local lhs assign rhs
     assing_multiple 'CHROOT  :=  /tmp/mash-ramdisk' lhs assign rhs
-    printf 'lhs=[%s] assign=[%s] rhs=[%s]\n' "$lhs" "$assign" "$rhs"
+    assert_equal $lhs 'CHROOT'
+    assert_equal $assign ':='
+    assert_equal $rhs '/tmp/mash-ramdisk'
+
+    print_pass
+}
+
+test_assign_multiple__case_leftover() {
+    _curr_test_=test_assign_multiple__case_leftover
+    no=$(expr $no + 1)
+
+    local left right leftover
+    assing_multiple 'LEFT  RIGHT one two three' left right leftover
+    assert_equal "$left" 'LEFT'
+    assert_equal "$right" 'RIGHT'
+    assert_equal "$leftover" 'one two three'
+
+    print_pass
+}
+
+test_assign_multiple__case_not_enough_data() {
+    _curr_test_=test_assign_multiple__case_not_enough_data
+    no=$(expr $no + 1)
+
+    local one two three
+    assing_multiple 'one two' one two three
+    assert_equal "$one" 'one'
+    assert_equal "$two" 'two'
+    assert_equal "$three" ''
+
+    print_pass
 }
 
 test_reeval() {
-    blah
+    #TODO: implement
+    false
 }
 
 test() {
-    test_assign_multiple
-    test_has_substr
-    printf '_name_=[%s]  _tsl_name_=[%s]' "$_name_" "$_tsl_name_"
+    set +x
+    local no=0
+
+    test_has_substr__true
+    test_has_substr__false
+    test_assign_multiple__case_exact
+    test_assign_multiple__case_leftover
+    test_assign_multiple__case_not_enough_data
 }
 
 if [ "$_name_" = "$_tsl_name_" ]; then

--- a/scripts/tests/test-small-lib.sh
+++ b/scripts/tests/test-small-lib.sh
@@ -1,0 +1,85 @@
+#! /bin/sh
+# Tests for small-lib.sh. Can be executed directly or sourced.
+
+# shellcheck disable=1091
+{
+    # Paths are relative to the chroot-setup project root
+    . ./scripts/small-lib.sh
+    . ./scripts/tests/lib-4test.sh
+}
+
+# must follow the imports otherwise _tsl_name_ gets overriden
+_name_="$(basename "$0")"
+_tsl_name_='test-small-lib.sh'
+echo "$_tsl_name_: _name_=[$_name_], _tsl_name_=[$_tsl_name_]"
+
+test_has_substr_OLD() {
+    printf '%s\n' 'POSITIVE:'
+    has_substr 'abc' 'a'
+    echo "rc=$?"
+    has_substr 'abc' 'ab'
+    echo "rc=$?"
+    has_substr 'abc' 'bc'
+    echo "rc=$?"
+    has_substr 'abc' 'abc'
+    echo "rc=$?"
+    has_substr 'ab$$c' '$$'
+    echo "rc=$?"
+
+    printf '%s\n' 'NEGATIVE:'
+    has_substr '' 'ab'
+    echo "rc=$?"
+    has_substr 'abc' 'ac'
+    echo "rc=$?"
+    has_substr 'abc' 'ba'
+    echo "rc=$?"
+    has_substr 'aabca' 'ba'
+    echo "rc=$?"
+    has_substr "abc" ''
+    echo "rc=$?"
+}
+
+test_has_substr() {
+    printf '%s\n' 'POSITIVE:'
+    has_substr 'abc' 'a'
+    echo "rc=$?"
+    has_substr 'abc' 'ab'
+    echo "rc=$?"
+    has_substr 'abc' 'bc'
+    echo "rc=$?"
+    has_substr 'abc' 'abc'
+    echo "rc=$?"
+    has_substr 'ab$$c' '$$'
+    echo "rc=$?"
+
+    printf '%s\n' 'NEGATIVE:'
+    has_substr '' 'ab'
+    echo "rc=$?"
+    has_substr 'abc' 'ac'
+    echo "rc=$?"
+    has_substr 'abc' 'ba'
+    echo "rc=$?"
+    has_substr 'aabca' 'ba'
+    echo "rc=$?"
+    has_substr "abc" ''
+    echo "rc=$?"
+}
+
+test_assign_multiple() {
+    assing_multiple 'CHROOT  :=  /tmp/mash-ramdisk' lhs assign rhs
+    printf 'lhs=[%s] assign=[%s] rhs=[%s]\n' "$lhs" "$assign" "$rhs"
+}
+
+test_reeval() {
+    blah
+}
+
+test() {
+    test_assign_multiple
+    test_has_substr
+    printf '_name_=[%s]  _tsl_name_=[%s]' "$_name_" "$_tsl_name_"
+}
+
+if [ "$_name_" = "$_tsl_name_" ]; then
+    test
+fi

--- a/scripts/tests/zz-test-all.sh
+++ b/scripts/tests/zz-test-all.sh
@@ -1,0 +1,34 @@
+#! /bin/sh
+
+# Run all tests in chroot-setup/scripts/tests
+
+_name_="$(basename "$0")"
+_ta_name_345_='zz-test-all.sh'
+echo "$_ta_name_345_: _name_=[$_name_], _ta_name_345_=[$_ta_name_345_]"
+
+print_header() {
+    local filename="$1"
+    printf '\n=== Running %s ===\n' $filename
+}
+
+test() {
+    # rc=0
+    print_header ./scripts/tests/lib-4test.sh
+    ./scripts/tests/lib-4test.sh test
+    # rc=$(expt $rc + $?)
+
+    print_header ./scripts/tests/test-small-lib.sh
+    ./scripts/tests/test-small-lib.sh
+    # rc=$(expt $rc + $?)
+
+    print_header ./scripts/tests/test-create-dot-env.sh
+    ./scripts/tests/test-create-dot-env.sh
+    # rc=$(expt $rc + $?)
+
+    printf '\nTOTAL: Tests failed: %u\n' $rc
+    return $rc
+}
+
+if [ "$_name_" = "$_ta_name_345_" ]; then
+    test
+fi


### PR DESCRIPTION
## Create-dot-env related reworks

- Add `expand-vars.sh` for expanding variables in shel snippets
   during chroot setup;
- Extract some common functions into `small-lib.sh` (to be refactored);
- Provide simple unit-test library (`lib-4test.sh`);
- Refactor `create-dot-env.sh`;
- Cover all modules with unit tests using `lib-4test.sh`.


Task: ya55en/mashmallow-0#46