### PR TITLE
Working tarballs creation ci action

### DIFF
--- a/.github/workflows/build-tarballs.yml
+++ b/.github/workflows/build-tarballs.yml
@@ -7,10 +7,10 @@ name: build-tarballs
 on:
   # Suppressing builds on push for now; leaving only chron-based builds.
 
-  # push:
-  #  branches:
-  #  # any branches; $default-branch doesn't seem to work
-  #    - *
+  push:
+    branches:
+    # any branches (must quote the asterisk); $default-branch doesn't seem to work
+      - '*'
 
   schedule:
     # every monday & wednesday, 3:15am EEST
@@ -34,8 +34,9 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt-get install -y debootstrap make curl
       - run: ./scripts/create-dot-env.sh > .env.mk
-      - run: make build/focal-headless.tar.${MASH_CHROOT_TAR_EXT}
-      - run: make build/focal-mate-desktop.tar.${MASH_CHROOT_TAR_EXT}
-      - run: echo ${{ secrets.YASSENS_GITHUB_TOKEN }} | gh auth login --with-token
-      - run: gh release upload --clobber ${MASH_CHROOT_RELEASE_TAG} ./build/focal-headless.tar.${MASH_CHROOT_TAR_EXT}
-      - run: gh release upload --clobber ${MASH_CHROOT_RELEASE_TAG} ./build/focal-mate-desktop.tar.${MASH_CHROOT_TAR_EXT}
+      - run: ./scripts/tests/zz-test-all.sh | ./scripts/tests/tapview
+      # - run: make build/focal-headless.tar.${MASH_CHROOT_TAR_EXT}
+      # - run: make build/focal-mate-desktop.tar.${MASH_CHROOT_TAR_EXT}
+      # - run: echo ${{ secrets.YASSENS_GITHUB_TOKEN }} | gh auth login --with-token
+      # - run: gh release upload --clobber ${MASH_CHROOT_RELEASE_TAG} ./build/focal-headless.tar.${MASH_CHROOT_TAR_EXT}
+      # - run: gh release upload --clobber ${MASH_CHROOT_RELEASE_TAG} ./build/focal-mate-desktop.tar.${MASH_CHROOT_TAR_EXT}

--- a/.github/workflows/build-tarballs.yml
+++ b/.github/workflows/build-tarballs.yml
@@ -5,15 +5,16 @@
 name: build-tarballs
 
 on:
-  push:
-    branches:
-      # any branches; $default-branch doesn't seem to work
-      - main
-      - 46-tarball-ci-action
-      # - '*'
+  # Suppressing builds on push for now; leaving only chron-based builds.
+
+  # push:
+  #  branches:
+  #  # any branches; $default-branch doesn't seem to work
+  #    - *
+
   schedule:
-    # every monday, thursday, friday, 3:15am EEST
-    - cron:  '15 0 * * 1,3,5'
+    # every monday & wednesday, 3:15am EEST
+    - cron:  '15 0 * * 1,4'
 
 jobs:
   build-focal-headless:
@@ -22,7 +23,7 @@ jobs:
     environment: STAGE
 
     env:
-      MASH_CHROOT_TAR_EXT: xz
+      MASH_CHROOT_TAR_EXT: gz
       MASH_CHROOT_USER_PSSWD_HASH: ${{ secrets.MASH_CHROOT_USER_PSSWD_HASH }}
       MASH_CHROOT_RELEASE_TAG: ${{ secrets.MASH_CHROOT_RELEASE_TAG }}
 

--- a/4make/inside-chroot/focal-headless.sh
+++ b/4make/inside-chroot/focal-headless.sh
@@ -53,7 +53,8 @@ setup_mashuser_sudo() {
 $MASH_USER ALL=(ALL) NOPASSWD:ALL
 EOS
 
-    chown "${MASH_UID}:${MASH_UID}" "$mashuser_sudo_file"
+    # chown "${MASH_UID}:${MASH_UID}" "$mashuser_sudo_file"
+    chown root:root "$mashuser_sudo_file"
     chmod 440 "$mashuser_sudo_file"
 }
 
@@ -70,26 +71,26 @@ EOS
     done
 }
 
-create_runtests_script() {
-    # Note that we do not source /etc/environment in this one, as this
-    # eliminates the mash PATH addition and mash cannot be found.
-    script_path="/home/${MASH_USER}/run-tests.sh"
+# create_runtests_script() {
+#     # Note that we do not source /etc/environment in this one, as this
+#     # eliminates the mash PATH addition and mash cannot be found.
+#     script_path="/home/${MASH_USER}/run-tests.sh"
 
-    cat >> "$script_path" << EOS
-#! /bin/sh
-. /etc/default/locale
+#     cat >> "$script_path" << EOS
+# #! /bin/sh
+# . /etc/default/locale
 
-#: mash: sourcing initializing scripts from ~/.bashrc.d/*.sh
-for file in "/home/$MASH_USER/.bashrc.d/"*.sh; do
-    . "\$file"
-done
+# #: mash: sourcing initializing scripts from ~/.bashrc.d/*.sh
+# for file in "/home/$MASH_USER/.bashrc.d/"*.sh; do
+#     . "\$file"
+# done
 
-cd /home/${MASH_USER}/ && ./test/e2e/smoke-e2e.sh "\$1"
-EOS
+# cd /home/${MASH_USER}/ && ./test/e2e/smoke-e2e.sh "\$1"
+# EOS
 
-    chown "${MASH_UID}:${MASH_UID}" "$script_path"
-    chmod u+x "$script_path"
-}
+#     chown "${MASH_UID}:${MASH_UID}" "$script_path"
+#     chmod u+x "$script_path"
+# }
 
 set_hostname() {
     # hostnamectl set-hostname "${CODENAME}-headless-chrooted"
@@ -113,7 +114,7 @@ main() {
     create_mash_user
     setup_mashuser_sudo
     add_source_locale_snippet
-    create_runtests_script
+    # create_runtests_script
     set_hostname
     do_cleanup
 }

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,10 @@ test-%:  _ensure_chroot
 	sudo chroot $(CHROOT) sudo -u mash /home/$(MASH_USER)/run-tests.sh "$*"
 
 
+test-tools:
+	./scripts/tests/zz-test-all.sh | ./scripts/tests/tapview
+
+
 clean-build:
 	rm -rf $(BUILD_DIR); mkdir -p $(BUILD_DIR)
 
@@ -194,5 +198,5 @@ status:
 .PHONY:  _ensure_chroot _ensure_no_chroot mount-chroot umount-chroot prep-chroot-dir chroot-down
 .PHONY:  clean-build clean-downloads clean-all clean
 .PHONY:  headless-up headless-down mate-desktop-up mate-desktop-down
-.PHONY:  test
+.PHONY:  test-% test-tools
 .PHONY:  sync-mash sync-downloads status

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ headless-up: $(FOCAL_HEADLESS_TAR).$(TAR_EXT)
 	./mount-chroot.sh
 	./4make/copy-mash-in-chroot.sh
 	make sync-downloads
+	sudo chown -R "${MASH_UID}:${MASH_UID}" "${CHROOT}/home/${MASH_USER}"
 	@printf 'Now do something in the chroot ;)  e.g.\n\n $$ sudo chroot $(CHROOT) bash\n\n'
 
 
@@ -114,6 +115,7 @@ mate-desktop-up:  $(MATE_DESKTOP_TAR).$(TAR_EXT)  prep-chroot-dir
 	./mount-chroot.sh
 	./4make/copy-mash-in-chroot.sh
 	make sync-downloads
+	sudo chown -R "${MASH_UID}:${MASH_UID}" "${CHROOT}/home/${MASH_USER}"
 	sudo chroot "$(CHROOT)" start-vnc.sh
 	@printf 'Now do something in the chroot ;)  e.g.\n\n $$ sudo chroot $(CHROOT) bash\n\n'
 

--- a/resources/README.md
+++ b/resources/README.md
@@ -1,0 +1,4 @@
+# Resources for the chroot environments
+
+Stuff we copy verbatim (or almost) to the chroot after it is built,
+like the VNC p_sswd file and test runners.

--- a/resources/run-tests.sh
+++ b/resources/run-tests.sh
@@ -1,0 +1,15 @@
+#! /bin/sh
+
+# shellcheck disable=1091
+. /etc/default/locale
+
+echo "$MASH_UID ${MASH_UID}" > /dev/null  # making sure this has expanded as it should
+
+#: mash: sourcing initializing scripts from ~/.bashrc.d/*.sh (We need to do
+#: this for non-interactive execution when .bashrc does not work.)
+for file in "/home/${MASH_USER}/.bashrc.d/"*.sh; do
+    # shellcheck disable=1090
+    . "$file"
+done
+
+cd "/home/$MASH_USER/" && ./test/e2e/smoke-e2e.sh "$1"

--- a/scripts/create-dot-env.sh
+++ b/scripts/create-dot-env.sh
@@ -48,20 +48,6 @@ should_be_processed() {
     has_substr "$line" '=' && has_substr "$line" '$${'
 }
 
-#do_positive_test() {
-#    case_no=$(expr $case_no + 1)
-#    if should_be_processed "$1"; then echo " case-$case_no OK"; else
-#        echo " case-$case_no FAILED"
-#    fi
-#}
-#
-#do_negative_test() {
-#    case_no=$(expr $case_no + 1)
-#    if ! should_be_processed "$1"; then echo " case-$case_no OK"; else
-#        echo " case-$case_no FAILED"
-#    fi
-#}
-
 main() {
     local OIFS="$IFS"
     local IFS=''

--- a/scripts/path-lib.sh
+++ b/scripts/path-lib.sh
@@ -2,7 +2,7 @@
 # path-lib.sh should be sourced.
 
 
-#: Returns a relative part of given path $1 from given directory $2 to
+#: Return a relative part of given path $1 from given directory $2 to
 #: the end of the path, stripping the part from the beginning to the
 #: given directory.
 relpath_from_dir() {
@@ -12,6 +12,7 @@ relpath_from_dir() {
     echo "$path" | sed "s:^.*/\?\($dir/.*$\):\1:"
 }
 
+# TODO: provide proper tests based on lib-4test.
 
 test_relpath_from_dir() {
     res="$(relpath_from_dir '/one/two/three/four/five' 'three')"  # expected three/four/five
@@ -22,4 +23,4 @@ test_relpath_from_dir() {
     echo $res
 }
 
-test_relpath_from_dir
+# test_relpath_from_dir

--- a/scripts/tests/tapview
+++ b/scripts/tests/tapview
@@ -1,0 +1,193 @@
+#! /bin/sh
+# tapview - a TAP (Test Anything Protocol) viewer in pure POSIX shell
+#
+# Copyright by Eric S. Raymond
+#
+# This code is intended to be embedded in your project. The author
+# grants permission for it to be distributed under the prevailing
+# license of your project if you choose, provided that license is
+# OSD-compliant; otherwise the following SPDX tag incorporates a
+# license by reference.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# This is version 1.1
+# A newer version may be available at https://gitlab.com/esr/tapview
+#
+# POSIX allows but does not mandate that -n suppresses emission of a
+# trailing newline in echo. Thus, some shell builtin echos don't do
+# that.  Cope gracefully.
+# shellcheck disable=SC2039
+if [ "$(echo -n "a"; echo "b")" != "ab" ]
+then
+    ECHO="echo"
+elif [ "$(/bin/echo -n "a"; /bin/echo "b")" = "ab" ]
+then
+    ECHO="/bin/echo"
+else
+    echo "tapview: bailing out, your echo lacks -n support."
+    exit 3
+fi
+
+OK="."
+FAIL="F"
+SKIP="s"
+TODO_NOT_OK="x"
+TODO_OK="u"
+
+ship_char() {
+    # shellcheck disable=SC2039
+    "${ECHO}" -n "$1"
+}
+
+ship_line() {
+    report="${report}${1}\n"
+}
+
+testcount=0
+failcount=0
+skipcount=0
+todocount=0
+test_before_plan=no
+test_after_plan=no
+expect=""
+status=0
+
+report=""
+IFS=""
+state=start
+while read -r line
+do
+    if expr "$line" : "Bail out!" >/dev/null
+    then
+	ship_line "$line"
+	status=2
+	break
+    fi
+    if expr "$line" : '1\.\.[0-9][0-9]*' >/dev/null
+    then
+	if [ "$expect" != "" ]
+	then
+	    if [ "${testcount}" -gt 0 ]
+	    then
+		echo ""
+	    fi
+	    ship_line "Cannot have more than one plan line."
+	    echo "${report}"
+	    exit 1
+	fi
+	if expr "$line" : ".* *SKIP" >/dev/null || expr "$line" : ".* *skip" >/dev/null
+	then
+	    ship_line "$line"
+	    echo "${report}"
+	    exit 1	# Not specified in the standard whether this should exit 1 or 0
+	fi
+	expect=$(expr "$line" : '1\.\.\([0-9][0-9]*\)')
+	continue
+    fi
+    if expr "$line" : "ok" >/dev/null
+    then
+	testcount=$((testcount + 1))
+	if [ "$expect" = "" ]
+	then
+	    test_before_plan=yes
+	else
+	    test_after_plan=yes
+	fi
+	if expr "$line" : ".*# *TODO" >/dev/null || expr "$line" : ".*# *todo" >/dev/null
+	then
+	    ship_char ${TODO_OK}
+	    ship_line "$line"
+	    todocount=$((todocount + 1))
+	elif expr "$line" : ".*# *SKIP" >/dev/null || expr "$line" : ".*# *skip" >/dev/null
+	then
+	    ship_char ${SKIP}
+	    ship_line "$line"
+	    skipcount=$((skipcount + 1))
+	else
+	    ship_char ${OK}
+	fi
+	state=ok
+	continue
+    fi
+    if expr "$line" : "not ok" >/dev/null
+    then
+	testcount=$((testcount + 1))
+	if [ "$expect" = "" ]
+	then
+	    test_before_plan=yes
+	else
+	    test_after_plan=yes
+	fi
+	if expr "$line" : ".*# *SKIP" >/dev/null || expr "$line" : ".*# *skip" >/dev/null
+	then
+	    ship_char "${SKIP}"
+	    state=ok
+	    skipcount=$((skipcount + 1))
+	    continue
+	fi
+	if expr "$line" : ".*# *TODO" >/dev/null || expr "$line" : ".*# *todo" >/dev/null
+	then
+	    ship_char ${TODO_NOT_OK}
+	    state=ok
+	    todocount=$((todocount + 1))
+	    continue
+	fi
+	ship_char "${FAIL}"
+	ship_line "$line"
+	state=not_ok
+	failcount=$((failcount + 1))
+	status=1
+	continue
+    fi
+    # shellcheck disable=SC2166
+    if [ "${state}" = "yaml" ]
+    then
+	ship_line "$line"
+	if expr "$line" : '[ 	]*\.\.\.' >/dev/null
+	then
+	    state=ok
+	fi
+    elif expr "$line" : "[ 	]*---" >/dev/null
+    then
+	ship_line "$line"
+	state=yaml
+    fi
+done
+
+/bin/echo ""
+
+if [ -z "$expect" ]
+then
+    # YD: inhibit to suit our use case
+    # ship_line "Missing a plan."
+    status=$status  # YD: was: status=1
+elif [ "$test_before_plan" = "yes" ] && [ "$test_after_plan" = "yes" ]
+then
+    ship_line "A plan line may only be placed before or after all tests."
+    status=1
+elif [ "${expect}" -gt "${testcount}" ]
+then
+    ship_line "Expected ${expect} tests but only ${testcount} ran."
+    status=1
+elif [ "${expect}" -lt "${testcount}" ]
+then
+    ship_line "Expected ${expect} tests but ${testcount} ran."
+    status=1
+fi
+
+report="${report}${testcount} tests, ${failcount} failures"
+if [ "$todocount" != 0 ]
+then
+    report="${report}, ${todocount} TODOs"
+fi
+if [ "$skipcount" != 0 ]
+then
+    report="${report}, ${skipcount} SKIPs"
+fi
+
+echo "${report}."
+
+exit "${status}"
+
+# end

--- a/scripts/tests/test-create-dot-env.sh
+++ b/scripts/tests/test-create-dot-env.sh
@@ -29,8 +29,8 @@ test_should_be_processed() {
     _curr_test_=test_should_be_processed
     no=$(expr $no + 1)
 
-    should_be_processed 'TAR_EXT := $${MASH_CHROOT_TAR_EXT:-gz}' || echo "RC=$?"
-    should_be_processed 'MASH_PSSWD_HASH := $${MASH_CHROOT_USER_PSSWD_HASH:-\$(MASH_PSSWD_HASH_DEFAULT)}' || echo "RC=$?"
+    assert_true should_be_processed 'TAR_EXT := $${MASH_CHROOT_TAR_EXT:-gz}'
+    assert_true should_be_processed 'MASH_PSSWD_HASH := $${MASH_CHROOT_USER_PSSWD_HASH:-\$(MASH_PSSWD_HASH_DEFAULT)}'
     assert_false should_be_processed 'MASH_PSSWD_HASH_DEFAULT := $$6$$coq/LvbNy'
     assert_false should_be_processed 'MASH_USER := mash'
     # assert_true should_be_processed 'MASH_USER := mash'  # fails - for checking how it runs with a failng test
@@ -38,7 +38,7 @@ test_should_be_processed() {
     print_pass
 }
 
-# shellcheck disable=2003,2016
+# shellcheck disable=2003,2016,2034
 test_e2e() {
     _curr_test_=test_e2e
     no=$(expr $no + 1)

--- a/scripts/tests/test-create-dot-env.sh
+++ b/scripts/tests/test-create-dot-env.sh
@@ -65,7 +65,8 @@ test() {
 
     test_split_line
     test_should_be_processed
-    test_e2e
+    # Consider GITHUB_ACTIONS - see issue ya55en/mash-0-chroot-setup#3
+    [ "$GITHUB_ACTIONS" = true ] || test_e2e
 }
 
 if [ "$_name_" = "$_tcde_name_" ]; then

--- a/scripts/tests/test-small-lib.sh
+++ b/scripts/tests/test-small-lib.sh
@@ -65,6 +65,7 @@ test_assign_multiple__case_leftover() {
     print_pass
 }
 
+# shellcheck disable=2034
 test_assign_multiple__case_not_enough_data() {
     _curr_test_=test_assign_multiple__case_not_enough_data
     no=$(expr $no + 1)

--- a/scripts/tests/zz-test-all.sh
+++ b/scripts/tests/zz-test-all.sh
@@ -8,25 +8,18 @@ echo "$_ta_name_345_: _name_=[$_name_], _ta_name_345_=[$_ta_name_345_]"
 
 print_header() {
     local filename="$1"
-    printf '\n=== Running %s ===\n' $filename
+    printf '\n=== Running %s ===\n' "$filename"
 }
 
 test() {
-    # rc=0
     print_header ./scripts/tests/lib-4test.sh
     ./scripts/tests/lib-4test.sh test
-    # rc=$(expt $rc + $?)
 
     print_header ./scripts/tests/test-small-lib.sh
     ./scripts/tests/test-small-lib.sh
-    # rc=$(expt $rc + $?)
 
     print_header ./scripts/tests/test-create-dot-env.sh
     ./scripts/tests/test-create-dot-env.sh
-    # rc=$(expt $rc + $?)
-
-    printf '\nTOTAL: Tests failed: %u\n' $rc
-    return $rc
 }
 
 if [ "$_name_" = "$_ta_name_345_" ]; then


### PR DESCRIPTION
## Working tarballs creation CI action.

- Add tools for processing shell scripts expanding variables before copying into the chroot.
- Extract some common functions into `small-lib.sh`
- Add `lib-4test.sh` library for unit-testing shell code;
- Add tests for `create-dot-env.sh` and `small-lib.sh`;
- Provide convenient make targets for running tests in the chroot;
- Provide a make target for running the unit tests of the tools listed above.

Part of ya55en/mashmallow-0#46
